### PR TITLE
half_set_predicate: Fix HSETP2_C constant buffer offset

### DIFF
--- a/src/video_core/shader/decode/half_set_predicate.cpp
+++ b/src/video_core/shader/decode/half_set_predicate.cpp
@@ -30,7 +30,7 @@ u32 ShaderIR::DecodeHalfSetPredicate(NodeBlock& bb, u32 pc) {
     case OpCode::Id::HSETP2_C:
         cond = instr.hsetp2.cbuf_and_imm.cond;
         h_and = instr.hsetp2.cbuf_and_imm.h_and;
-        op_b = GetOperandAbsNegHalf(GetConstBuffer(instr.cbuf34.index, instr.cbuf34.offset),
+        op_b = GetOperandAbsNegHalf(GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset()),
                                     instr.hsetp2.cbuf.abs_b, instr.hsetp2.cbuf.negate_b);
         break;
     case OpCode::Id::HSETP2_IMM:


### PR DESCRIPTION
`instr.cbuf34.offset` doesn't multiply by 4 the value. `instr.cbuf34.GetOffset()` has to be used instead. Should we declare abstract values as private to avoid these kind of bugs?

This fixes an assert hit on Fire Emblem: Three Houses about unaligned constant buffer access. What exactly is fixed graphically wasn't tested in-game, but it might have some impact since `HSETP2_C` usages would read the wrong offset. I tried testing it in-game but it takes an awful lot of time to boot.