### PR TITLE
video_core: Silent miscellaneous warnings  

### DIFF
--- a/src/video_core/buffer_cache/buffer_block.h
+++ b/src/video_core/buffer_cache/buffer_block.h
@@ -69,7 +69,6 @@ protected:
 private:
     CacheAddr cache_addr{};
     CacheAddr cache_addr_end{};
-    u64 pages{};
     std::size_t size{};
     u64 epoch{};
 };

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -18,10 +18,7 @@
 #include "video_core/buffer_cache/buffer_block.h"
 #include "video_core/buffer_cache/map_interval.h"
 #include "video_core/memory_manager.h"
-
-namespace VideoCore {
-class RasterizerInterface;
-}
+#include "video_core/rasterizer_interface.h"
 
 namespace VideoCommon {
 
@@ -348,7 +345,6 @@ private:
         const CacheAddr cache_addr_end = cache_addr + size - 1;
         u64 page_start = cache_addr >> block_page_bits;
         const u64 page_end = cache_addr_end >> block_page_bits;
-        const u64 num_pages = page_end - page_start + 1;
         while (page_start <= page_end) {
             auto it = blocks.find(page_start);
             if (it == blocks.end()) {
@@ -417,7 +413,10 @@ private:
         return false;
     }
 
+    VideoCore::RasterizerInterface& rasterizer;
+    Core::System& system;
     std::unique_ptr<StreamBuffer> stream_buffer;
+
     TBufferType stream_buffer_handle{};
 
     bool invalidated = false;
@@ -441,8 +440,7 @@ private:
     std::list<TBuffer> pending_destruction{};
     u64 epoch{};
     u64 modified_ticks{};
-    VideoCore::RasterizerInterface& rasterizer;
-    Core::System& system;
+
     std::recursive_mutex mutex;
 };
 

--- a/src/video_core/engines/fermi_2d.cpp
+++ b/src/video_core/engines/fermi_2d.cpp
@@ -10,8 +10,7 @@
 
 namespace Tegra::Engines {
 
-Fermi2D::Fermi2D(VideoCore::RasterizerInterface& rasterizer, MemoryManager& memory_manager)
-    : rasterizer{rasterizer}, memory_manager{memory_manager} {}
+Fermi2D::Fermi2D(VideoCore::RasterizerInterface& rasterizer) : rasterizer{rasterizer} {}
 
 void Fermi2D::CallMethod(const GPU::MethodCall& method_call) {
     ASSERT_MSG(method_call.method < Regs::NUM_REGS,

--- a/src/video_core/engines/fermi_2d.h
+++ b/src/video_core/engines/fermi_2d.h
@@ -33,7 +33,7 @@ namespace Tegra::Engines {
 
 class Fermi2D final {
 public:
-    explicit Fermi2D(VideoCore::RasterizerInterface& rasterizer, MemoryManager& memory_manager);
+    explicit Fermi2D(VideoCore::RasterizerInterface& rasterizer);
     ~Fermi2D() = default;
 
     /// Write the value to the register identified by method.
@@ -145,7 +145,6 @@ public:
 
 private:
     VideoCore::RasterizerInterface& rasterizer;
-    MemoryManager& memory_manager;
 
     /// Performs the copy from the source surface to the destination surface as configured in the
     /// registers.

--- a/src/video_core/engines/kepler_memory.cpp
+++ b/src/video_core/engines/kepler_memory.cpp
@@ -15,7 +15,7 @@
 namespace Tegra::Engines {
 
 KeplerMemory::KeplerMemory(Core::System& system, MemoryManager& memory_manager)
-    : system{system}, memory_manager{memory_manager}, upload_state{memory_manager, regs.upload} {}
+    : system{system}, upload_state{memory_manager, regs.upload} {}
 
 KeplerMemory::~KeplerMemory() = default;
 

--- a/src/video_core/engines/kepler_memory.h
+++ b/src/video_core/engines/kepler_memory.h
@@ -65,7 +65,6 @@ public:
 
 private:
     Core::System& system;
-    MemoryManager& memory_manager;
     Upload::State upload_state;
 };
 

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -524,7 +524,7 @@ void Maxwell3D::ProcessQueryCondition() {
 void Maxwell3D::ProcessSyncPoint() {
     const u32 sync_point = regs.sync_info.sync_point.Value();
     const u32 increment = regs.sync_info.increment.Value();
-    const u32 cache_flush = regs.sync_info.unknown.Value();
+    [[maybe_unused]] const u32 cache_flush = regs.sync_info.unknown.Value();
     if (increment) {
         system.GPU().IncrementSyncPoint(sync_point);
     }
@@ -626,10 +626,10 @@ Texture::TICEntry Maxwell3D::GetTICEntry(u32 tic_index) const {
     Texture::TICEntry tic_entry;
     memory_manager.ReadBlockUnsafe(tic_address_gpu, &tic_entry, sizeof(Texture::TICEntry));
 
-    const auto r_type{tic_entry.r_type.Value()};
-    const auto g_type{tic_entry.g_type.Value()};
-    const auto b_type{tic_entry.b_type.Value()};
-    const auto a_type{tic_entry.a_type.Value()};
+    [[maybe_unused]] const auto r_type{tic_entry.r_type.Value()};
+    [[maybe_unused]] const auto g_type{tic_entry.g_type.Value()};
+    [[maybe_unused]] const auto b_type{tic_entry.b_type.Value()};
+    [[maybe_unused]] const auto a_type{tic_entry.a_type.Value()};
 
     // TODO(Subv): Different data types for separate components are not supported
     DEBUG_ASSERT(r_type == g_type && r_type == b_type && r_type == a_type);

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -8,15 +8,13 @@
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/engines/maxwell_dma.h"
 #include "video_core/memory_manager.h"
-#include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_base.h"
 #include "video_core/textures/decoders.h"
 
 namespace Tegra::Engines {
 
-MaxwellDMA::MaxwellDMA(Core::System& system, VideoCore::RasterizerInterface& rasterizer,
-                       MemoryManager& memory_manager)
-    : system{system}, rasterizer{rasterizer}, memory_manager{memory_manager} {}
+MaxwellDMA::MaxwellDMA(Core::System& system, MemoryManager& memory_manager)
+    : system{system}, memory_manager{memory_manager} {}
 
 void MaxwellDMA::CallMethod(const GPU::MethodCall& method_call) {
     ASSERT_MSG(method_call.method < Regs::NUM_REGS,

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -20,10 +20,6 @@ namespace Tegra {
 class MemoryManager;
 }
 
-namespace VideoCore {
-class RasterizerInterface;
-}
-
 namespace Tegra::Engines {
 
 /**
@@ -33,8 +29,7 @@ namespace Tegra::Engines {
 
 class MaxwellDMA final {
 public:
-    explicit MaxwellDMA(Core::System& system, VideoCore::RasterizerInterface& rasterizer,
-                        MemoryManager& memory_manager);
+    explicit MaxwellDMA(Core::System& system, MemoryManager& memory_manager);
     ~MaxwellDMA() = default;
 
     /// Write the value to the register identified by method.
@@ -179,8 +174,6 @@ public:
 
 private:
     Core::System& system;
-
-    VideoCore::RasterizerInterface& rasterizer;
 
     MemoryManager& memory_manager;
 

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -35,9 +35,9 @@ GPU::GPU(Core::System& system, VideoCore::RendererBase& renderer, bool is_async)
     memory_manager = std::make_unique<Tegra::MemoryManager>(system, rasterizer);
     dma_pusher = std::make_unique<Tegra::DmaPusher>(*this);
     maxwell_3d = std::make_unique<Engines::Maxwell3D>(system, rasterizer, *memory_manager);
-    fermi_2d = std::make_unique<Engines::Fermi2D>(rasterizer, *memory_manager);
+    fermi_2d = std::make_unique<Engines::Fermi2D>(rasterizer);
     kepler_compute = std::make_unique<Engines::KeplerCompute>(system, rasterizer, *memory_manager);
-    maxwell_dma = std::make_unique<Engines::MaxwellDMA>(system, rasterizer, *memory_manager);
+    maxwell_dma = std::make_unique<Engines::MaxwellDMA>(system, *memory_manager);
     kepler_memory = std::make_unique<Engines::KeplerMemory>(system, *memory_manager);
 }
 

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -285,8 +285,8 @@ private:
 
 protected:
     std::unique_ptr<Tegra::DmaPusher> dma_pusher;
-    VideoCore::RendererBase& renderer;
     Core::System& system;
+    VideoCore::RendererBase& renderer;
 
 private:
     std::unique_ptr<Tegra::MemoryManager> memory_manager;

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -50,7 +50,7 @@ public:
     /// and invalidated
     virtual void FlushAndInvalidateRegion(CacheAddr addr, u64 size) = 0;
 
-    // Notify the rasterizer to send all written commands to the host GPU.
+    /// Notify the rasterizer to send all written commands to the host GPU.
     virtual void FlushCommands() = 0;
 
     /// Notify rasterizer that a frame is about to finish

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -708,8 +708,6 @@ void RasterizerOpenGL::DrawArrays() {
         return;
     }
 
-    const auto& regs = gpu.regs;
-
     SyncColorMask();
     SyncFragmentColorClampState();
     SyncMultiSampleState();

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -295,7 +295,7 @@ std::set<GLenum> GetSupportedFormats() {
 
 CachedShader::CachedShader(const ShaderParameters& params, ProgramType program_type,
                            GLShader::ProgramResult result)
-    : RasterizerCacheObject{params.host_ptr}, host_ptr{params.host_ptr}, cpu_addr{params.cpu_addr},
+    : RasterizerCacheObject{params.host_ptr}, cpu_addr{params.cpu_addr},
       unique_identifier{params.unique_identifier}, program_type{program_type},
       disk_cache{params.disk_cache}, precompiled_programs{params.precompiled_programs},
       entries{result.second}, code{std::move(result.first)}, shader_length{entries.shader_length} {}

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -106,7 +106,6 @@ private:
 
     ShaderDiskCacheUsage GetUsage(const ProgramVariant& variant) const;
 
-    u8* host_ptr{};
     VAddr cpu_addr{};
     u64 unique_identifier{};
     ProgramType program_type{};

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -51,7 +51,7 @@ public:
     }
 
 protected:
-    void DecorateSurfaceName();
+    void DecorateSurfaceName() override;
 
     View CreateView(const ViewParams& view_key) override;
     View CreateViewInner(const ViewParams& view_key, bool is_proxy);

--- a/src/video_core/shader/decode/float_set.cpp
+++ b/src/video_core/shader/decode/float_set.cpp
@@ -15,7 +15,6 @@ using Tegra::Shader::OpCode;
 
 u32 ShaderIR::DecodeFloatSet(NodeBlock& bb, u32 pc) {
     const Instruction instr = {program_code[pc]};
-    const auto opcode = OpCode::Decode(instr);
 
     const Node op_a = GetOperandAbsNegFloat(GetRegister(instr.gpr8), instr.fset.abs_a != 0,
                                             instr.fset.neg_a != 0);

--- a/src/video_core/shader/decode/float_set_predicate.cpp
+++ b/src/video_core/shader/decode/float_set_predicate.cpp
@@ -16,7 +16,6 @@ using Tegra::Shader::Pred;
 
 u32 ShaderIR::DecodeFloatSetPredicate(NodeBlock& bb, u32 pc) {
     const Instruction instr = {program_code[pc]};
-    const auto opcode = OpCode::Decode(instr);
 
     const Node op_a = GetOperandAbsNegFloat(GetRegister(instr.gpr8), instr.fsetp.abs_a != 0,
                                             instr.fsetp.neg_a != 0);

--- a/src/video_core/shader/decode/integer_set.cpp
+++ b/src/video_core/shader/decode/integer_set.cpp
@@ -14,7 +14,6 @@ using Tegra::Shader::OpCode;
 
 u32 ShaderIR::DecodeIntegerSet(NodeBlock& bb, u32 pc) {
     const Instruction instr = {program_code[pc]};
-    const auto opcode = OpCode::Decode(instr);
 
     const Node op_a = GetRegister(instr.gpr8);
     const Node op_b = [&]() {

--- a/src/video_core/shader/decode/integer_set_predicate.cpp
+++ b/src/video_core/shader/decode/integer_set_predicate.cpp
@@ -16,7 +16,6 @@ using Tegra::Shader::Pred;
 
 u32 ShaderIR::DecodeIntegerSetPredicate(NodeBlock& bb, u32 pc) {
     const Instruction instr = {program_code[pc]};
-    const auto opcode = OpCode::Decode(instr);
 
     const Node op_a = GetRegister(instr.gpr8);
 

--- a/src/video_core/shader/decode/predicate_set_register.cpp
+++ b/src/video_core/shader/decode/predicate_set_register.cpp
@@ -15,7 +15,6 @@ using Tegra::Shader::OpCode;
 
 u32 ShaderIR::DecodePredicateSetRegister(NodeBlock& bb, u32 pc) {
     const Instruction instr = {program_code[pc]};
-    const auto opcode = OpCode::Decode(instr);
 
     UNIMPLEMENTED_IF_MSG(instr.generates_cc,
                          "Condition codes generation in PSET is not implemented");

--- a/src/video_core/texture_cache/surface_params.h
+++ b/src/video_core/texture_cache/surface_params.h
@@ -58,7 +58,6 @@ public:
     std::size_t GetHostSizeInBytes() const {
         std::size_t host_size_in_bytes;
         if (GetCompressionType() == SurfaceCompression::Converted) {
-            constexpr std::size_t rgb8_bpp = 4ULL;
             // ASTC is uncompressed in software, in emulated as RGBA8
             host_size_in_bytes = 0;
             for (u32 level = 0; level < num_levels; ++level) {

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -308,8 +308,6 @@ protected:
         if (!guard_render_targets && surface->IsRenderTarget()) {
             ManageRenderTargetUnregister(surface);
         }
-        const GPUVAddr gpu_addr = surface->GetGpuAddr();
-        const CacheAddr cache_ptr = surface->GetCacheAddr();
         const std::size_t size = surface->GetSizeInBytes();
         const VAddr cpu_addr = surface->GetCpuAddr();
         rasterizer.UpdatePagesCachedCount(cpu_addr, size, -1);


### PR DESCRIPTION
* texture_cache/surface_params: Remove unused local variable

* rasterizer_interface: Add missing documentation commentary

* maxwell_dma: Remove unused rasterizer reference

* video_core/gpu: Sort member declaration order to silent -Wreorder warning

* fermi_2d: Remove unused MemoryManager reference

* video_core: Silent unused variable warnings

* buffer_cache: Silent -Wreorder warnings

* kepler_memory: Remove unused MemoryManager reference

* gl_texture_cache: Add missing override

* buffer_cache: Add missing include

* shader/decode: Remove unused variables