### PR TITLE
float_set_predicate: Add missing negation bit for the second operand

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -873,6 +873,7 @@ union Instruction {
     union {
         BitField<0, 3, u64> pred0;
         BitField<3, 3, u64> pred3;
+        BitField<6, 1, u64> neg_b;
         BitField<7, 1, u64> abs_a;
         BitField<39, 3, u64> pred39;
         BitField<42, 1, u64> neg_pred;

--- a/src/video_core/shader/decode/float_set_predicate.cpp
+++ b/src/video_core/shader/decode/float_set_predicate.cpp
@@ -18,8 +18,8 @@ u32 ShaderIR::DecodeFloatSetPredicate(NodeBlock& bb, u32 pc) {
     const Instruction instr = {program_code[pc]};
     const auto opcode = OpCode::Decode(instr);
 
-    const Node op_a = GetOperandAbsNegFloat(GetRegister(instr.gpr8), instr.fsetp.abs_a != 0,
-                                            instr.fsetp.neg_a != 0);
+    Node op_a = GetOperandAbsNegFloat(GetRegister(instr.gpr8), instr.fsetp.abs_a != 0,
+                                      instr.fsetp.neg_a != 0);
     Node op_b = [&]() {
         if (instr.is_b_imm) {
             return GetImmediate19(instr);
@@ -29,12 +29,13 @@ u32 ShaderIR::DecodeFloatSetPredicate(NodeBlock& bb, u32 pc) {
             return GetConstBuffer(instr.cbuf34.index, instr.cbuf34.GetOffset());
         }
     }();
-    op_b = GetOperandAbsNegFloat(op_b, instr.fsetp.abs_b, false);
+    op_b = GetOperandAbsNegFloat(std::move(op_b), instr.fsetp.abs_b, instr.fsetp.neg_b);
 
     // We can't use the constant predicate as destination.
     ASSERT(instr.fsetp.pred3 != static_cast<u64>(Pred::UnusedIndex));
 
-    const Node predicate = GetPredicateComparisonFloat(instr.fsetp.cond, op_a, op_b);
+    const Node predicate =
+        GetPredicateComparisonFloat(instr.fsetp.cond, std::move(op_a), std::move(op_b));
     const Node second_pred = GetPredicate(instr.fsetp.pred39, instr.fsetp.neg_pred != 0);
 
     const OperationCode combiner = GetPredicateCombiner(instr.fsetp.op);


### PR DESCRIPTION
This bit was not listed in envytools. Negate `op_b` when it's required.