### PR TITLE
externals: update fmt to 6.0.0

### DIFF
--- a/src/core/hle/service/fatal/fatal.cpp
+++ b/src/core/hle/service/fatal/fatal.cpp
@@ -5,7 +5,7 @@
 #include <array>
 #include <cstring>
 #include <ctime>
-#include <fmt/time.h>
+#include <fmt/chrono.h>
 #include "common/file_util.h"
 #include "common/logging/log.h"
 #include "common/scm_rev.h"

--- a/src/core/reporter.cpp
+++ b/src/core/reporter.cpp
@@ -6,7 +6,7 @@
 #include <fstream>
 
 #include <fmt/format.h>
-#include <fmt/time.h>
+#include <fmt/chrono.h>
 #include <json.hpp>
 
 #include "common/file_util.h"

--- a/src/core/reporter.cpp
+++ b/src/core/reporter.cpp
@@ -5,8 +5,8 @@
 #include <ctime>
 #include <fstream>
 
-#include <fmt/format.h>
 #include <fmt/chrono.h>
+#include <fmt/format.h>
 #include <json.hpp>
 
 #include "common/file_util.h"


### PR DESCRIPTION
This is required for yuzu to build on Linux.
Credit to Cleverking2003
Fixes 2798